### PR TITLE
Dashboard chart select

### DIFF
--- a/src/App/AppProvider.js
+++ b/src/App/AppProvider.js
@@ -17,6 +17,7 @@ export class AppProvider extends React.Component {
         this.state = {
             page: 'dashboard',
             favorites:['BTC', 'ETH', 'XMR', 'DOGE'],
+            timeInterval: 'months',
             // #13 @ 02:20
             ...this.savedSettings(),
             setPage: this.setPage,
@@ -25,7 +26,8 @@ export class AppProvider extends React.Component {
             isInFavorites: this.isInFavorites,
             confirmFavorites: this.confirmFavorites,
             setCurrentFavorite: this.setCurrentFavorite,
-            setFilteredCoins: this.setFilteredCoins
+            setFilteredCoins: this.setFilteredCoins,
+            changeChartSelect: this.changeChartSelect
         }
     }
 
@@ -61,7 +63,7 @@ export class AppProvider extends React.Component {
             {
                 name: this.state.currentFavorite,
                 data: results.map((ticker, index) => [
-                    moment().subtract({months: TIME_UNITS - index}).valueOf(),
+                    moment().subtract({[this.state.timeInterval]: TIME_UNITS - index}).valueOf(), // timeInterval specified as key of object
                         ticker.USD // y axis value
                 ])
             }
@@ -94,7 +96,7 @@ export class AppProvider extends React.Component {
                     this.state.currentFavorite,
                     ['USD'],
                     moment()
-                    .subtract({months: units})
+                    .subtract({[this.state.timeInterval]: units})
                     .toDate()
                 )
             )
@@ -173,6 +175,11 @@ export class AppProvider extends React.Component {
     
     setFilteredCoins = (filteredCoins) => this.setState({filteredCoins}) //#26 @ 00:49
     
+    changeChartSelect = (value) => {
+        console.log(value);
+        this.setState({timeInterval: value, historical: null}, this.fetchHistorical);
+    }
+
     // # 12 @ 04:04
     render() {
         return (

--- a/src/Dashboard/ChartSelect.js
+++ b/src/Dashboard/ChartSelect.js
@@ -1,3 +1,10 @@
 import styled from 'styled-components';
+import {backgroundColor2, fontSize2} from '../Shared/Styles';
 
-export default styled.select ``; // 'select' is an html menu dropdown
+export default styled.select ` // 'select' is an html menu dropdown
+    ${backgroundColor2}
+    ${fontSize2}
+    color: #1163c9;
+    border: 1px solid;
+    float: right;
+`;

--- a/src/Dashboard/PriceChart.js
+++ b/src/Dashboard/PriceChart.js
@@ -11,13 +11,16 @@ ReactHighcharts.Highcharts.setOptions(HighchartsTheme);
 export default function () {
     return (
         <AppContext.Consumer>
-            {({historical}) =>
+            {({historical, changeChartSelect}) =>
             <Tile>
-                <ChartSelect>
+                <ChartSelect
+                    defaultValue='months'
+                    onChange={e => changeChartSelect(e.target.value)}               
+                >
                     <option value ='days'> Days </option>
-                    <option value ='days'> Weeks </option>
-                    <option value ='days'> Months </option>
-                    <option value ='days'> Years </option>
+                    <option value ='weeks'> Weeks </option>
+                    <option value ='months'> Months </option>
+                    <option value ='years'> Years </option>
                 </ChartSelect>
                { historical ? <ReactHighcharts config={highchartsConfig(historical)}/>
                 : <div> Loading Historical Data</div>


### PR DESCRIPTION
1. Added stylized ChartSelect component to generate time unit of measurements in the form of days, weeks, months, and years for historical pricing data view. 
2. Styled-components used for default theme/visual options for dropdown menu, moved to right side of rendered tile. 
3. Default value is set to months, ‘onClick’ handler triggers new data fetch for end user updated options, e.g. changing from ‘Days’ to ‘Weeks’ populates a new pricing data graph for the last 10 weeks. 

![2019-05-15 11 12 03](https://user-images.githubusercontent.com/30557542/57787075-bca3c480-7702-11e9-945a-306879faa1ee.gif)
